### PR TITLE
Fix typo: 'stareing' → 'staring'

### DIFF
--- a/perform/perform.py
+++ b/perform/perform.py
@@ -944,7 +944,7 @@ class Perform(commands.Cog):
         """
         Stare someone!
         """
-        embed = await kawaiiembed(self, ctx, "is stareing!", "stare")
+        embed = await kawaiiembed(self, ctx, "is staring!", "stare")
         if not isinstance(embed, discord.Embed):
             return await ctx.send(embed)
         used = await self.config.user(ctx.author).stare()


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix typo 'stareing' to 'staring' in the kawaiiembed call for the stare command